### PR TITLE
Fix remaining eslint2 test failures

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -2,7 +2,6 @@ var source;
 
 module.exports = function (ast, traverse, code) {
   source = code;
-  ast.sourceType = "module";
   ast.range = [ast.start, ast.end];
   traverse(ast, astTransformVisitor);
 };

--- a/index.js
+++ b/index.js
@@ -422,7 +422,7 @@ exports.parseNoPatch = function (code) {
   } catch (err) {
     if (err instanceof SyntaxError) {
       err.lineNumber = err.loc.line;
-      err.column = err.loc.column;
+      err.column = err.loc.column + 1;
 
       // remove trailing "(LINE:COLUMN)" acorn message and add in esprima syntax error message start
       err.message = "Line " + err.lineNumber + ": " + err.message.replace(/ \((\d+):(\d+)\)$/, "");

--- a/index.js
+++ b/index.js
@@ -380,7 +380,9 @@ function monkeypatch() {
   };
 }
 
-exports.parse = function (code) {
+exports.parse = function (code, options) {
+  options = options || {};
+
   try {
     monkeypatch();
   } catch (err) {
@@ -388,12 +390,12 @@ exports.parse = function (code) {
     process.exit(1);
   }
 
-  return exports.parseNoPatch(code);
+  return exports.parseNoPatch(code, options);
 }
 
-exports.parseNoPatch = function (code) {
+exports.parseNoPatch = function (code, options) {
   var opts = {
-    sourceType: "module",
+    sourceType: options.sourceType || "module",
     strictMode: true,
     allowImportExportEverywhere: false, // consistent with espree
     allowReturnOutsideFunction: true,

--- a/test/integration.js
+++ b/test/integration.js
@@ -13,6 +13,9 @@ var errorLevel = 2;
 
 var baseEslintOpts = {
   parser: require.resolve(".."),
+  parserOptions: {
+    sourceType: "script"
+  }
 };
 
 /**


### PR DESCRIPTION
This PR contains two fixes for the remaining test failures with eslint2.

The first aligns the column property from babel/babylon with eslint/espree. The later one starts counting the columns at 1 and babylon starts at 0.


The second fix respects the **sourceType** from the eslint _parserOptions_ in babel-eslint.
The strict tests were all failing as they now implicitly changes its behavior based on the sourceType as of eslint 2.0. The fix I added is to respect the _parserOption_ **sourceType**, so that people could set sourceType to `"script"` with babel-eslint.
I first thought also to align the default value for **sourceType** with eslint (`"script"`), but that would not be bc and it is probably more common to use` "module"` with babel-eslint anyway. So I ended up falling back to `"module"` if no **sourceType** specified.

What do you think about that?
