### PR TITLE
Add Failing test for no-use-before-define

### DIFF
--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1140,7 +1140,7 @@ describe("verify", function () {
   it("visits excluded properties left of spread #95", function () {
     verifyAndAssertMessages(
       "var originalObject = {}; var {field1, field2, ...clone} = originalObject;",
-      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
+      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1, "no-use-before-define": 1 },
       []
     );
   });
@@ -1148,7 +1148,7 @@ describe("verify", function () {
   it("visits excluded properties left of spread #210", function () {
     verifyAndAssertMessages(
       "const props = { yo: 'yo' }; const { ...otherProps } = props;",
-      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
+      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1, "no-use-before-define": 1 },
       []
     );
   });


### PR DESCRIPTION
I couldn't figure out why exactly this is happening. Has something todo with the visiting in the VariableDeclaration.
https://github.com/hzoo/babel-eslint/blob/eslint2/index.js#L329